### PR TITLE
Restrict filters for two \- methods

### DIFF
--- a/lib/resclass.gi
+++ b/lib/resclass.gi
@@ -2286,7 +2286,7 @@ InstallOtherMethod( AdditiveInverseOp,
 ##
 InstallOtherMethod( \-,
                     "for residue class union and ring element (ResClasses)",
-                    ReturnTrue, [ IsListOrCollection, IsObject ], 0,
+                    ReturnTrue, [ IsResidueClassUnion, IsObject ], 0,
                     function ( U, x ) return U + (-x); end );
 
 #############################################################################
@@ -2295,7 +2295,7 @@ InstallOtherMethod( \-,
 ##
 InstallOtherMethod( \-,
                     "for ring element and residue class union (ResClasses)",
-                    ReturnTrue, [ IsObject, IsListOrCollection ], 0,
+                    ReturnTrue, [ IsObject, IsResidueClassUnion ], 0,
                     function ( x, U ) return (-U) + x; end );
 
 #############################################################################


### PR DESCRIPTION
The new filters match the info string of the methods.

Resolves point 6 of https://github.com/gap-system/gap/issues/2164