### PR TITLE
Stop using (Un)HideGlobalVariables

### DIFF
--- a/lib/resclaux.g
+++ b/lib/resclaux.g
@@ -18,20 +18,6 @@ RESCLASSES_VIEWINGFORMAT_BACKUP := "long";
 
 #############################################################################
 ##
-#V  One-character global variables ...
-##
-##  ... should not be overwritten when reading test files, e.g., although
-##  one-letter variable names are used in test files frequently.
-##  This is just the list of their names.
-##
-##  The actual caching is done by `ResClassesDoThingsToBeDoneBeforeTest' and
-##  `ResClassesDoThingsToBeDoneAfterTest'.
-##
-BindGlobal( "ONE_LETTER_GLOBALS",
-  List( "ABCDFGHIJKLMNOPQRSTUVWYabcdefghijklmnopqrstuvwxyz", ch -> [ch] ) );
-
-#############################################################################
-##
 #F  ResClassesDoThingsToBeDoneBeforeTest(  )
 #F  ResClassesDoThingsToBeDoneAfterTest(  )
 ##
@@ -43,13 +29,11 @@ BindGlobal( "ResClassesDoThingsToBeDoneBeforeTest",
     SetAssertionLevel(0);
     RESCLASSES_VIEWINGFORMAT_BACKUP := RESCLASSES_VIEWINGFORMAT;;
     ResidueClassUnionViewingFormat("long");
-    CallFuncList(HideGlobalVariables,ONE_LETTER_GLOBALS);
   end );
 
 BindGlobal( "ResClassesDoThingsToBeDoneAfterTest",
 
   function (  )
-    CallFuncList(UnhideGlobalVariables,ONE_LETTER_GLOBALS);
     ResidueClassUnionViewingFormat(RESCLASSES_VIEWINGFORMAT_BACKUP);
     SetAssertionLevel(RESCLASSES_ASSERTIONLEVEL_BACKUP);
     SetInfoLevel(InfoWarning,RESCLASSES_WARNINGLEVEL_BACKUP);


### PR DESCRIPTION
These functions are marked as obsolete in GAP master, which causes
warnings to appear when using them. Calling them was only used for
tests, and I could not see why. So it seems reasonable to disable this.

Note that RCWA also accesses `ONE_LETTER_GLOBALS`, which this PR removes. Thus this PR should only be merged in conjunction with https://github.com/gap-packages/rcwa/pull/10