### PR TITLE
Add \- method for a ring element and a ring

### DIFF
--- a/lib/resclass.gi
+++ b/lib/resclass.gi
@@ -2300,6 +2300,15 @@ InstallOtherMethod( \-,
 
 #############################################################################
 ##
+#M  \-( <x>, <U> ) . . . . . . . . . . . . . .  for a ring element and a ring
+##
+InstallOtherMethod( \-,
+                    "for a ring element and a ring (ResClasses)",
+                    IsElmsColls, [ IsRingElement, IsRing ], 0,
+                    function ( x, U ) return (-U) + x; end );
+
+#############################################################################
+##
 #M  AdditiveInverseOp( <R> ) . . . . . . . . . . . . . . .  for the base ring
 ##
 InstallOtherMethod( AdditiveInverseOp,


### PR DESCRIPTION
This fixes the regression introduced by PR #4 for resclasses, i.e., together with PR #5, it makes the tests pass for me again with the master branch.

There are still some related failures in RCWA, but also many other test failures. I am investigating those now, and will address them with a separate PR (either for resclasses or RCWA, depending on the outcome of the analysis).