### PR TITLE
ci: also run tests for latest RCWA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
+    - GAP_PKGS_TO_CLONE="rcwa"
+    - GAP_PKGS_TO_BUILD="io profiling grape"
 
 addons:
   apt_packages:
@@ -25,6 +27,8 @@ before_script:
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
+  # also run RCWA tests
+  - cd $GAPROOT/pkg/rcwa && $TRAVIS_BUILD_DIR/scripts/run_tests.sh
 after_script:
   - bash scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This should help catch changes to resclasses that break RCWA.

Let's wait if the Travis tests really pass before merging this.