### PR TITLE
Add .release file, tweak Travis integration

### DIFF
--- a/.release
+++ b/.release
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This file is executed by the `release` script from
+# https://github.com/gap-system/ReleaseTools
+rm -rf .travis.yml .codecov.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: c
 env:
   global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
     - GAP_PKGS_TO_CLONE="rcwa"
     - GAP_PKGS_TO_BUILD="io profiling grape"
 
@@ -10,25 +8,25 @@ addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: GAPBRANCH="master"
-    - env: GAPBRANCH="stable-4.9"
-    - env: GAPBRANCH="stable-4.10"
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=stable-4.10
 
 branches:
   only:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
   # also run RCWA tests
-  - cd $GAPROOT/pkg/rcwa && $TRAVIS_BUILD_DIR/scripts/run_tests.sh
+  - cd $HOME/gap/pkg/rcwa && $TRAVIS_BUILD_DIR/scripts/run_tests.sh
 after_script:
   - bash scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The .release file ensures that some stuff we don't want to see in the
tarball are removed by ReleaseTools when creating the tarball.

The Travis changes are purely janitorial.