### PR TITLE
Change IsZ_pi from a property to a category

### DIFF
--- a/lib/z_pi.gd
+++ b/lib/z_pi.gd
@@ -15,7 +15,7 @@
 ##
 DeclareConstructor( "Z_piCons", [ IsRing, IsList ] );
 DeclareGlobalFunction( "Z_pi" );
-DeclareProperty( "IsZ_pi", IsEuclideanRing );
+DeclareCategory( "IsZ_pi", IsEuclideanRing and IsCyclotomicCollection );
 
 #############################################################################
 ##

--- a/lib/z_pi.gi
+++ b/lib/z_pi.gi
@@ -25,7 +25,8 @@ InstallMethod( Z_piCons, "natural Z_pi (ResClasses)", true,
                              IsRing and IsAttributeStoringRep ),
                     rec( primes := Immutable( pi ) ) );
     SetIsTrivial( R, false );
-    SetIsZ_pi( R, true );
+    SetIsWholeFamily( R, false );
+    SetFilterObj( R, IsZ_pi );
     SetZero( R, 0 ); SetOne( R, 1 );
     SetIsFinite( R, false ); SetSize( R, infinity );
     SetIsAssociative( R, true ); SetIsCommutative( R, true );
@@ -51,15 +52,6 @@ InstallGlobalFunction( Z_pi,
     then Error( "Z_pi( <pi> ): <pi> must be a set of primes.\n" ); fi;
     return Z_piCons( IsRing, Set( pi ) );
   end );
-
-#############################################################################
-##
-#M  IsZ_pi( <obj> ) . . . . . . . . . . . . . . . . . . . . . . . . .  Z_(pi)
-##
-##  Return false, if the contrary is not known explicitly.
-##
-InstallOtherMethod( IsZ_pi, "for non-Z_(pi) (ResClasses)", true,
-                    [ IsObject ], 0, ReturnFalse );
 
 #############################################################################
 ##


### PR DESCRIPTION
This seems correct, as there were no real methods to compute it. Also, it is very similar to IsIntegers, which is also a category.

This makes a so-called "hidden" implication created by DeclareProperty explicit, thereby resolving a bunch of warnings that show up if one starts the upcoming GAP 4.11 with the `-N` command line option, and then loads this package.

For some information on the background of this, see also <https://github.com/gap-system/gap/issues/1649> and <https://github.com/gap-system/gap/issues/2336>